### PR TITLE
SystemUI: Add support for GameSpace [1/2]

### DIFF
--- a/core/java/android/provider/Settings.java
+++ b/core/java/android/provider/Settings.java
@@ -5196,6 +5196,20 @@ public final class Settings {
         public static final String POINTER_SPEED = "pointer_speed";
 
         /**
+         * GameSpace: List of added games by user
+         * @hide
+         */
+        @Readable
+        public static final String GAMESPACE_GAME_LIST = "gamespace_game_list";
+
+        /**
+         * GameSpace: Whether fullscreen intent will be suppressed while in game session
+         * @hide
+         */
+        @Readable
+        public static final String GAMESPACE_SUPPRESS_FULLSCREEN_INTENT = "gamespace_suppress_fullscreen_intent";
+
+        /**
          * Whether lock-to-app will be triggered by long-press on recents.
          * @hide
          */

--- a/core/res/AndroidManifest.xml
+++ b/core/res/AndroidManifest.xml
@@ -712,6 +712,10 @@
     <!-- Used to force the state of battery led -->
     <protected-broadcast android:name="android.intent.action.BATTERY_LED_STATE_OVERRIDE" />
 
+    <!-- GameSpace -->
+    <protected-broadcast android:name="io.chaldeaprjkt.gamespace.action.GAME_START" />
+    <protected-broadcast android:name="io.chaldeaprjkt.gamespace.action.GAME_STOP" />
+
     <!-- ====================================================================== -->
     <!--                          RUNTIME PERMISSIONS                           -->
     <!-- ====================================================================== -->

--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/StatusBar.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/StatusBar.java
@@ -235,6 +235,7 @@ import com.android.systemui.statusbar.policy.ConfigurationController.Configurati
 import com.android.systemui.statusbar.policy.DeviceProvisionedController;
 import com.android.systemui.statusbar.policy.DeviceProvisionedController.DeviceProvisionedListener;
 import com.android.systemui.statusbar.policy.ExtensionController;
+import com.android.systemui.statusbar.policy.GameSpaceManager;
 import com.android.systemui.statusbar.policy.KeyguardStateController;
 import com.android.systemui.statusbar.policy.UserInfoControllerImpl;
 import com.android.systemui.statusbar.policy.UserSwitcherController;
@@ -529,6 +530,8 @@ public class StatusBar extends SystemUI implements
     private final StatusBarLocationPublisher mStatusBarLocationPublisher;
     private final StatusBarIconController mStatusBarIconController;
     private final StatusBarHideIconsForBouncerManager mStatusBarHideIconsForBouncerManager;
+
+    protected GameSpaceManager mGameSpaceManager;
 
     // expanded notifications
     // the sliding/resizing panel within the notification window
@@ -927,6 +930,7 @@ public class StatusBar extends SystemUI implements
 
         mActivityIntentHelper = new ActivityIntentHelper(mContext);
         mActivityLaunchAnimator = activityLaunchAnimator;
+        mGameSpaceManager = new GameSpaceManager(mContext, mKeyguardStateController);
 
         // The status bar background may need updating when the ongoing call status changes.
         mOngoingCallController.addCallback((animate) -> maybeUpdateBarMode());
@@ -1456,6 +1460,7 @@ public class StatusBar extends SystemUI implements
         filter.addAction(DevicePolicyManager.ACTION_SHOW_DEVICE_MONITORING_DIALOG);
         filter.addAction(Intent.ACTION_SCREEN_CAMERA_GESTURE);
         mBroadcastDispatcher.registerReceiver(mBroadcastReceiver, filter, null, UserHandle.ALL);
+        mGameSpaceManager.observe();
     }
 
     public void updateDismissAllVisibility(boolean visible) {
@@ -4343,6 +4348,10 @@ public class StatusBar extends SystemUI implements
 
     public NotificationGutsManager getGutsManager() {
         return mGutsManager;
+    }
+
+    public GameSpaceManager getGameSpaceManager() {
+        return mGameSpaceManager;
     }
 
     boolean isTransientShown() {

--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/StatusBarNotificationActivityStarter.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/StatusBarNotificationActivityStarter.java
@@ -75,6 +75,7 @@ import com.android.systemui.statusbar.notification.logging.NotificationLogger;
 import com.android.systemui.statusbar.notification.row.ExpandableNotificationRow;
 import com.android.systemui.statusbar.notification.row.ExpandableNotificationRowDragController;
 import com.android.systemui.statusbar.notification.row.OnUserInteractionCallback;
+import com.android.systemui.statusbar.policy.GameSpaceManager;
 import com.android.systemui.statusbar.policy.HeadsUpUtil;
 import com.android.systemui.statusbar.policy.KeyguardStateController;
 import com.android.systemui.wmshell.BubblesManager;
@@ -597,6 +598,11 @@ public class StatusBarNotificationActivityStarter implements NotificationActivit
 
     @VisibleForTesting
     void handleFullScreenIntent(NotificationEntry entry) {
+        GameSpaceManager gameSpace = mStatusBar.getGameSpaceManager();
+        if (gameSpace != null && gameSpace.shouldSuppressFullScreenIntent()) {
+            return;
+        }
+
         if (mNotificationInterruptStateProvider.shouldLaunchFullScreenIntentWhenAdded(entry)) {
             if (shouldSuppressFullScreenIntent(entry)) {
                 mLogger.logFullScreenIntentSuppressedByDnD(entry.getKey());

--- a/packages/SystemUI/src/com/android/systemui/statusbar/policy/GameSpaceManager.kt
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/policy/GameSpaceManager.kt
@@ -1,0 +1,151 @@
+/*
+ * Copyright (C) 2021 Chaldeaprjkt
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+package com.android.systemui.statusbar.policy
+
+import android.app.ActivityTaskManager
+import android.content.BroadcastReceiver
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.os.Handler
+import android.os.Looper
+import android.os.Message
+import android.os.PowerManager
+import android.os.RemoteException
+import android.os.UserHandle
+import android.provider.Settings
+import com.android.systemui.dagger.SysUISingleton
+import com.android.systemui.shared.system.ActivityManagerWrapper
+import com.android.systemui.shared.system.TaskStackChangeListener
+
+import java.util.Arrays
+import javax.inject.Inject
+
+@SysUISingleton
+class GameSpaceManager @Inject constructor(
+    private val context: Context,
+    private val keyguardStateController: KeyguardStateController,
+) {
+    private val handler by lazy { GameSpaceHandler(Looper.getMainLooper()) }
+    private val taskManager by lazy { ActivityTaskManager.getService() }
+    private val activityManager by lazy { ActivityManagerWrapper.getInstance() }
+
+    private var activeGame: String? = null
+    private var isRegistered = false
+
+    private val mTaskStackChangeListener = object : TaskStackChangeListener() {
+        override fun onTaskStackChanged() {
+            handler.sendEmptyMessage(MSG_UPDATE_FOREGROUND_APP)
+        }
+    }
+
+    private val interactivityReceiver = object : BroadcastReceiver() {
+        override fun onReceive(context: Context?, intent: Intent?) {
+            when (intent?.action) {
+                Intent.ACTION_SCREEN_OFF -> {
+                    activeGame = null
+                    handler.sendEmptyMessage(MSG_DISPATCH_FOREGROUND_APP)
+                }
+            }
+        }
+    }
+
+    private val keyguardStateCallback = object : KeyguardStateController.Callback {
+        override fun onKeyguardShowingChanged() {
+            if (keyguardStateController.isShowing) return
+            handler.sendEmptyMessage(MSG_UPDATE_FOREGROUND_APP)
+        }
+    }
+
+    private inner class GameSpaceHandler(looper: Looper?) : Handler(looper, null, true) {
+        override fun handleMessage(msg: Message) {
+            when (msg.what) {
+                MSG_UPDATE_FOREGROUND_APP -> checkForegroundApp()
+                MSG_DISPATCH_FOREGROUND_APP -> dispatchForegroundApp()
+            }
+        }
+    }
+
+    private fun checkForegroundApp() {
+        try {
+            val info = taskManager.focusedRootTaskInfo
+            info?.topActivity ?: return
+            val packageName = info.topActivity?.packageName
+            activeGame = checkGameList(packageName)
+            handler.sendEmptyMessage(MSG_DISPATCH_FOREGROUND_APP)
+        } catch (e: RemoteException) {
+        }
+    }
+
+    private fun dispatchForegroundApp() {
+        val pm = context.getSystemService(Context.POWER_SERVICE) as PowerManager
+        if (!pm.isInteractive && activeGame != null) return
+        val action = if (activeGame != null) ACTION_GAME_START else ACTION_GAME_STOP
+        Intent(action).apply {
+            setPackage(GAMESPACE_PACKAGE)
+            component = ComponentName.unflattenFromString(RECEIVER_CLASS)
+            putExtra(EXTRA_CALLER_NAME, context.packageName)
+            if (activeGame != null) putExtra(EXTRA_ACTIVE_GAME, activeGame)
+            addFlags(Intent.FLAG_RECEIVER_REPLACE_PENDING
+                or Intent.FLAG_RECEIVER_FOREGROUND
+                or Intent.FLAG_RECEIVER_INCLUDE_BACKGROUND)
+            context.sendBroadcastAsUser(this, UserHandle.SYSTEM)
+        }
+    }
+
+    fun observe() {
+        if (isRegistered) {
+            activityManager.unregisterTaskStackListener(mTaskStackChangeListener)
+        }
+        activityManager.registerTaskStackListener(mTaskStackChangeListener)
+        isRegistered = true;
+        handler.sendEmptyMessage(MSG_UPDATE_FOREGROUND_APP)
+        context.registerReceiver(interactivityReceiver, IntentFilter().apply {
+            addAction(Intent.ACTION_SCREEN_OFF)
+        })
+        keyguardStateController.addCallback(keyguardStateCallback)
+    }
+
+    fun isGameActive() = activeGame != null
+
+    fun shouldSuppressFullScreenIntent() =
+        Settings.System.getInt(context.contentResolver,
+            Settings.System.GAMESPACE_SUPPRESS_FULLSCREEN_INTENT, 0) == 1 && isGameActive()
+
+    private fun checkGameList(packageName: String?): String? {
+        packageName ?: return null
+        val games = Settings.System.getString(context.contentResolver, Settings.System.GAMESPACE_GAME_LIST)
+        if (games.isNullOrEmpty())
+            return null
+
+        return games.split(";")
+            .map { it.split("=").first() }
+            .firstOrNull { it == packageName }
+    }
+
+    companion object {
+        private const val ACTION_GAME_START = "io.chaldeaprjkt.gamespace.action.GAME_START"
+        private const val ACTION_GAME_STOP = "io.chaldeaprjkt.gamespace.action.GAME_STOP"
+        private const val GAMESPACE_PACKAGE = "io.chaldeaprjkt.gamespace"
+        private const val RECEIVER_CLASS = "io.chaldeaprjkt.gamespace/.gamebar.GameBroadcastReceiver"
+        private const val EXTRA_CALLER_NAME = "source"
+        private const val EXTRA_ACTIVE_GAME = "package_name"
+        private const val MSG_UPDATE_FOREGROUND_APP = 0
+        private const val MSG_DISPATCH_FOREGROUND_APP = 1
+    }
+}


### PR DESCRIPTION
This is an addon for GameSpace for broadcasting about game start/stop.
Additionally, it also has special option for suppressing fullscreen
intent like incoming call.

This also squash commits:
- SystemUI: Improve GameSpace lifecycle and broadcast handling
- GameSpaceManager: Handle various case against "locking screen" scenario

Change-Id: I89a92695bbd868d5ad09d56a0719a7b06a26f935
Signed-off-by: Dinesh Kumar <dseera6@gmail.com>